### PR TITLE
In dynamic columns, transform european decimal format

### DIFF
--- a/src/main/scala/io/arlas/data/transform/DataFrameValidator.scala
+++ b/src/main/scala/io/arlas/data/transform/DataFrameValidator.scala
@@ -20,8 +20,9 @@
 package io.arlas.data.transform
 
 import io.arlas.data.model.DataModel
-import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
+import org.apache.spark.sql.types.{DataType, DoubleType, StringType, StructField, StructType, TimestampType}
 import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.functions.{col, regexp_replace, to_timestamp}
 
 class DataFrameValidator(dataModel: DataModel) extends ArlasTransformer(dataModel) {
 
@@ -47,13 +48,19 @@ class DataFrameValidator(dataModel: DataModel) extends ArlasTransformer(dataMode
   }
 
   def withValidDynamicColumnsType()(df: DataFrame): DataFrame = {
+
     //Dynamic columns only support double values
-    val columns = df.columns.map(column => {
-      if (dataModel.dynamicFields.contains(column))
-        df.col(column).cast(DoubleType)
-      else df.col(column)
-    })
-    df.select(columns: _*)
+    //For those dynamic columns, if it is a string, replace possible coma "," (decimal european format) in decimal with a dot ".", that spark supports
+    df.columns.filter(dataModel.dynamicFields.contains(_)).foldLeft(df){
+                             (dataframe, column) =>
+                               if (df.schema.filter(c => c.name == column && c.dataType == StringType).nonEmpty) {
+                                 dataframe
+                                   .withColumn(column, regexp_replace(col(column), ",", ".").cast(DoubleType))
+                               } else if (df.schema.filter(c => c.name == column && c.dataType == DoubleType).isEmpty) {
+                                 dataframe.withColumn(column, col(column).cast(DoubleType))
+                               } else dataframe
+                                           }
+
   }
 
   override def transformSchema(schema: StructType): StructType = {

--- a/src/test/scala/io/arlas/data/transform/DataFrameValidatorTest.scala
+++ b/src/test/scala/io/arlas/data/transform/DataFrameValidatorTest.scala
@@ -69,4 +69,23 @@ class DataFrameValidatorTest extends ArlasTest {
 
     assertDataFrameEquality(transformedDF, expectedDF)
   }
+
+  "DataFrameValidator " should " cast dynamic column with european format to DoubleType if necessary" in {
+
+    val dataModel = DataModel(timeFormat = "dd/MM/yyyy HH:mm:ssXXX", visibilityTimeout = 120)
+
+    val sourceDF = rawDF
+      .withColumnRenamed("lat", "oldlat")
+      .withColumnRenamed("lon", "oldlon")
+      .withColumn("lat", regexp_replace(col("oldlat").cast(StringType), "\\.", ","))
+      .withColumn("lon", regexp_replace(col("oldlon").cast(StringType), "\\.", ","))
+      .drop("oldlat", "oldlon")
+
+    val expectedDF = rawDF
+
+    val transformedDF: DataFrame = sourceDF
+      .enrichWithArlas(new DataFrameValidator(dataModel))
+
+    assertDataFrameEquality(transformedDF, expectedDF)
+  }
 }


### PR DESCRIPTION
In european decimal format, separator is a coma
but Spark doesn't support it