### PR TITLE
Add values mapper

### DIFF
--- a/src/main/scala/io/arlas/data/transform/OtherColValuesMapper.scala
+++ b/src/main/scala/io/arlas/data/transform/OtherColValuesMapper.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.data.transform
+
+import io.arlas.data.model.DataModel
+import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.functions._
+
+/**
+* Map some values to another values (of the same type).
+* From the doc, supported types are doubles, strings or booleans but in source code
+* we see that all numerical types are converted to double (float, long...)
+* => see https://spark.apache.org/docs/2.2.0/api/java/org/apache/spark/sql/DataFrameNaFunctions
+* .html#replace-java.lang.String:A-java.util.Map-
+* Target column may be a new one, or an existing one (i.a. same column).
+* If sourceColumn and valuesMap are not of the same type, this will not break (simply not replace any value)
+* @param dataModel
+* @param sourceColumn
+* @param targetColumn
+* @param valuesMap
+*/
+class OtherColValuesMapper[T](dataModel   : DataModel,
+                              sourceColumn: String,
+                              targetColumn: String,
+                              valuesMap   : Map[T, T]) extends ArlasTransformer(dataModel, Vector(sourceColumn))  {
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+
+    valuesMap match {
+      case m if m.isEmpty => dataset.toDF()
+      case _ =>
+        val df = if (sourceColumn == targetColumn) dataset.toDF() else dataset.toDF().withColumn(targetColumn, col(sourceColumn))
+        df.na.replace(targetColumn, valuesMap)
+    }
+  }
+
+  override def transformSchema(schema: StructType): StructType = {
+    val transformedSchema = super.transformSchema(schema)
+    val sourceColumnDataType = transformedSchema.fields.filter(_.name == sourceColumn).head.dataType
+
+    if (!transformedSchema.fieldNames.contains(targetColumn))
+      transformedSchema.add(StructField(targetColumn, sourceColumnDataType, true))
+    else {
+      val targetColumnDataType = transformedSchema.fields.filter(_.name == targetColumn).head.dataType
+      if (targetColumnDataType != sourceColumnDataType) {
+        throw new DataFrameException(s"Source and target columns should be of the same type, currently source is ${sourceColumnDataType} and target ${targetColumnDataType}")
+      }
+      transformedSchema
+    }
+  }
+
+}

--- a/src/main/scala/io/arlas/data/transform/SameColValuesMapper.scala
+++ b/src/main/scala/io/arlas/data/transform/SameColValuesMapper.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.data.transform
+
+import io.arlas.data.model.DataModel
+
+class SameColValuesMapper[T](dataModel   : DataModel,
+                             sourceColumn: String,
+                             valuesMap   : Map[T, T])
+  extends OtherColValuesMapper[T](dataModel,
+                                  sourceColumn,
+                                  sourceColumn,
+                                  valuesMap) {
+
+}

--- a/src/test/scala/io/arlas/data/transform/OtherColValuesMapperTest.scala
+++ b/src/test/scala/io/arlas/data/transform/OtherColValuesMapperTest.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.data.transform
+
+import io.arlas.data.sql._
+import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructType}
+
+class OtherColValuesMapperTest extends ArlasTest {
+
+  import spark.implicits._
+
+  val testSchema = StructType(
+    List(
+      StructField("id", StringType, true),
+      StructField("timestamp", StringType, true),
+      StructField("lat", DoubleType, true),
+      StructField("lon", DoubleType, true),
+      StructField("sourcestring", StringType, true),
+      StructField("sourcedouble", DoubleType, true)
+      ))
+
+  val testData = Seq(
+    ("ObjectA", "01/06/2018 00:00:00+02:00", 55.921028, 17.320418, "test", 0.0),
+    ("ObjectA", "01/06/2018 00:00:10+02:00", 55.920875, 17.319322, "test", 0.0),
+    ("ObjectA", "01/06/2018 00:00:31+02:00", 55.920583, 17.31733, "other-test", 1.0),
+    ("ObjectB", "01/06/2018 00:00:10+02:00", 55.920437, 17.316335, "out", 2.0))
+
+  val testDF     = spark.createDataFrame(testData.toDF().rdd, testSchema)
+
+  "WithValuesMapper " should "replace values of type string in another column" in {
+
+    val expectedData = Seq(
+      ("ObjectA", "01/06/2018 00:00:00+02:00", 55.921028, 17.320418, "test", 0.0, "success"),
+      ("ObjectA", "01/06/2018 00:00:10+02:00", 55.920875, 17.319322, "test", 0.0, "success"),
+      ("ObjectA", "01/06/2018 00:00:31+02:00", 55.920583, 17.31733, "other-test", 1.0, "other-success"),
+      ("ObjectB", "01/06/2018 00:00:10+02:00", 55.920437, 17.316335, "out", 2.0, "out"))
+
+    val expectedSchema = testSchema.add(StructField("targetstring", StringType))
+
+    val transformedDF = testDF.enrichWithArlas(
+      new OtherColValuesMapper(dataModel, "sourcestring", "targetstring", Map("test" -> "success", "other-test" -> "other-success")))
+
+    assertDataFrameEquality(transformedDF, spark.createDataFrame(expectedData.toDF().rdd, expectedSchema))
+  }
+
+  "WithValuesMapper " should "replace values of another type" in {
+
+    val expectedData = Seq(
+      ("ObjectA", "01/06/2018 00:00:00+02:00", 55.921028, 17.320418, "test", 99.0),
+      ("ObjectA", "01/06/2018 00:00:10+02:00", 55.920875, 17.319322, "test", 99.0),
+      ("ObjectA", "01/06/2018 00:00:31+02:00", 55.920583, 17.31733, "other-test", 100.0),
+      ("ObjectB", "01/06/2018 00:00:10+02:00", 55.920437, 17.316335, "out", 2.0))
+
+    val transformedDF = testDF.enrichWithArlas(
+      new OtherColValuesMapper(dataModel, "sourcedouble", "sourcedouble", Map(0.0 -> 99.0, 1.0 -> 100.0)))
+
+    assertDataFrameEquality(transformedDF, spark.createDataFrame(expectedData.toDF().rdd, testSchema))
+  }
+
+  "WithValuesMapper " should "throw exception with target column of another type" in {
+
+    val thrown = intercept[DataFrameException] {
+                                                        testDF.enrichWithArlas(
+                                                          new OtherColValuesMapper(dataModel, "sourcestring", "sourcedouble", Map("test" -> "value")))
+                                                      }
+
+    assert(
+      thrown.getMessage == "Source and target columns should be of the same type, currently source is StringType and target DoubleType")
+  }
+
+}

--- a/src/test/scala/io/arlas/data/transform/SameColValuesMapperTest.scala
+++ b/src/test/scala/io/arlas/data/transform/SameColValuesMapperTest.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.arlas.data.transform
+
+import io.arlas.data.sql._
+import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructType}
+
+class SameColValuesMapperTest extends ArlasTest {
+
+  import spark.implicits._
+
+  val testSchema = StructType(
+    List(
+      StructField("id", StringType, true),
+      StructField("timestamp", StringType, true),
+      StructField("lat", DoubleType, true),
+      StructField("lon", DoubleType, true),
+      StructField("sourcestring", StringType, true)
+      ))
+
+  val testData = Seq(
+    ("ObjectA", "01/06/2018 00:00:00+02:00", 55.921028, 17.320418, "test"),
+    ("ObjectA", "01/06/2018 00:00:10+02:00", 55.920875, 17.319322, "test"),
+    ("ObjectA", "01/06/2018 00:00:31+02:00", 55.920583, 17.31733, "other-test"),
+    ("ObjectB", "01/06/2018 00:00:10+02:00", 55.920437, 17.316335, "out"))
+
+  val testDF     = spark.createDataFrame(testData.toDF().rdd, testSchema)
+
+  "WithValuesMapper " should "replace values of type string in same column" in {
+
+    val expectedData = Seq(
+      ("ObjectA", "01/06/2018 00:00:00+02:00", 55.921028, 17.320418, "success"),
+      ("ObjectA", "01/06/2018 00:00:10+02:00", 55.920875, 17.319322, "success"),
+      ("ObjectA", "01/06/2018 00:00:31+02:00", 55.920583, 17.31733, "other-success"),
+      ("ObjectB", "01/06/2018 00:00:10+02:00", 55.920437, 17.316335, "out"))
+
+    val transformedDF = testDF.enrichWithArlas(
+      new OtherColValuesMapper(dataModel, "sourcestring", "sourcestring", Map("test" -> "success", "other-test" -> "other-success")))
+
+    assertDataFrameEquality(transformedDF, spark.createDataFrame(expectedData.toDF().rdd, testSchema))
+  }
+
+}


### PR DESCRIPTION
For a given column, map strings to other strings.
Result can be in same column or another.
Could not make it generic because udf cannot be.
If it were generic, it could replace "ValueReplacer".