### PR TITLE
Remove DataModel object parameter in ArlasTransformer constructor

### DIFF
--- a/src/main/scala/io/arlas/data/transform/ArlasTransformer.scala
+++ b/src/main/scala/io/arlas/data/transform/ArlasTransformer.scala
@@ -19,28 +19,12 @@
 
 package io.arlas.data.transform
 
-import io.arlas.data.model.DataModel
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.ml.{Transformer => SparkTransformer}
-import org.apache.spark.sql.types.{
-  BinaryType,
-  BooleanType,
-  ByteType,
-  DataType,
-  DateType,
-  DoubleType,
-  FloatType,
-  IntegerType,
-  LongType,
-  ShortType,
-  StringType,
-  StructType,
-  TimestampType
-}
+import org.apache.spark.sql.types.StructType
 
-abstract class ArlasTransformer(val dataModel: DataModel,
-                                val requiredCols: Vector[String] = Vector.empty)
+abstract class ArlasTransformer(val requiredCols: Vector[String] = Vector.empty)
     extends SparkTransformer {
 
   override def copy(extra: ParamMap): SparkTransformer = {
@@ -52,12 +36,7 @@ abstract class ArlasTransformer(val dataModel: DataModel,
   }
 
   def checkSchema(schema: StructType): StructType = {
-    val allRequiredCols = requiredCols ++ Vector(
-      dataModel.timestampColumn,
-      dataModel.idColumn,
-      dataModel.latColumn,
-      dataModel.lonColumn) ++ dataModel.dynamicFields.toSeq
-    val colsNotFound = allRequiredCols.distinct.diff(schema.fieldNames)
+    val colsNotFound = requiredCols.distinct.diff(schema.fieldNames)
     if (colsNotFound.length > 0) {
       throw new DataFrameException(
         s"The ${colsNotFound.mkString(", ")} columns are not included in the DataFrame with the following columns ${schema.fieldNames

--- a/src/main/scala/io/arlas/data/transform/DataFrameFormatter.scala
+++ b/src/main/scala/io/arlas/data/transform/DataFrameFormatter.scala
@@ -20,18 +20,11 @@
 package io.arlas.data.transform
 
 import io.arlas.data.model.DataModel
-import org.apache.spark.sql.types.{
-  DataType,
-  DoubleType,
-  StringType,
-  StructField,
-  StructType,
-  TimestampType
-}
+import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.functions.{col, regexp_replace, to_timestamp}
 
-class DataFrameFormatter(dataModel: DataModel) extends ArlasTransformer(dataModel) {
+class DataFrameFormatter(dataModel: DataModel) extends ArlasTransformer() {
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     dataset.toDF

--- a/src/main/scala/io/arlas/data/transform/FlowFragmentMapper.scala
+++ b/src/main/scala/io/arlas/data/transform/FlowFragmentMapper.scala
@@ -32,9 +32,10 @@ class FlowFragmentMapper(dataModel: DataModel,
                          spark: SparkSession,
                          aggregationColumnName: String,
                          averageColumns: List[String] = Nil)
-    extends ArlasTransformer(
-      dataModel,
-      Vector(arlasTimestampColumn, aggregationColumnName) ++ averageColumns.toVector) {
+    extends ArlasTransformer(Vector(arlasTimestampColumn,
+                                    aggregationColumnName,
+                                    dataModel.latColumn,
+                                    dataModel.lonColumn) ++ averageColumns.toVector) {
 
   override def transform(dataset: Dataset[_]): DataFrame = {
 

--- a/src/main/scala/io/arlas/data/transform/HmmProcessor.scala
+++ b/src/main/scala/io/arlas/data/transform/HmmProcessor.scala
@@ -19,7 +19,7 @@
 
 package io.arlas.data.transform
 
-import io.arlas.data.model.{DataModel, MLModel}
+import io.arlas.data.model.MLModel
 import io.arlas.data.transform.ArlasTransformerColumns.arlasTimestampColumn
 import io.arlas.ml.classification.Hmm
 import io.arlas.ml.parameter.State
@@ -33,14 +33,12 @@ import org.slf4j.LoggerFactory
 import scala.collection.mutable.ArrayBuffer
 import scala.util.{Failure, Success}
 
-class HmmProcessor(dataModel: DataModel,
-                   spark: SparkSession,
-                   sourceColumn: String,
+class HmmProcessor(sourceColumn: String,
                    hmmModel: MLModel,
                    partitionColumn: String,
                    resultColumn: String,
                    hmmWindowSize: Int)
-    extends ArlasTransformer(dataModel, Vector(partitionColumn)) {
+    extends ArlasTransformer(Vector(partitionColumn)) {
 
   @transient lazy val logger = LoggerFactory.getLogger(this.getClass)
   val UNKNOWN_RESULT = "Unknown"

--- a/src/main/scala/io/arlas/data/transform/IdUpdater.scala
+++ b/src/main/scala/io/arlas/data/transform/IdUpdater.scala
@@ -32,8 +32,8 @@ import org.apache.spark.sql.{DataFrame, Dataset}
   * @param idColumn
   */
 class IdUpdater(dataModel: DataModel, idColumn: String)
-    extends ArlasTransformer(dataModel,
-                             Vector(idColumn, arlasTrackTimestampStart, arlasTrackTimestampEnd)) {
+    extends ArlasTransformer(
+      Vector(idColumn, arlasTrackTimestampStart, arlasTrackTimestampEnd, dataModel.idColumn)) {
 
   override def transform(dataset: Dataset[_]): DataFrame = {
 

--- a/src/main/scala/io/arlas/data/transform/WithArlasTimestamp.scala
+++ b/src/main/scala/io/arlas/data/transform/WithArlasTimestamp.scala
@@ -21,7 +21,6 @@ package io.arlas.data.transform
 
 import java.time.format.{DateTimeFormatter, DateTimeParseException}
 import java.time.{ZoneOffset, ZonedDateTime}
-
 import io.arlas.data.model.DataModel
 import io.arlas.data.transform.ArlasTransformerColumns._
 import org.apache.spark.sql.expressions.UserDefinedFunction
@@ -29,7 +28,8 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset}
 
-class WithArlasTimestamp(dataModel: DataModel) extends ArlasTransformer(dataModel) {
+class WithArlasTimestamp(dataModel: DataModel)
+    extends ArlasTransformer(Vector(dataModel.timestampColumn)) {
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     val timestampConversion = getUdf(dataModel.timeFormat)

--- a/src/main/scala/io/arlas/data/transform/WithArlasVisibilityStateFromTimestamp.scala
+++ b/src/main/scala/io/arlas/data/transform/WithArlasVisibilityStateFromTimestamp.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.{DataFrame, Dataset}
 @Deprecated
 //TODO remove as soon as tests don't rely on it anymore
 class WithArlasVisibilityStateFromTimestamp(dataModel: DataModel, visibilityTimeout: Int)
-    extends ArlasTransformer(dataModel, Vector(arlasTimestampColumn, arlasPartitionColumn)) {
+    extends ArlasTransformer(Vector(arlasTimestampColumn, arlasPartitionColumn, dataModel.idColumn)) {
 
   override def transform(dataset: Dataset[_]): DataFrame = {
 

--- a/src/main/scala/io/arlas/data/transform/WithDurationFromId.scala
+++ b/src/main/scala/io/arlas/data/transform/WithDurationFromId.scala
@@ -19,7 +19,6 @@
 
 package io.arlas.data.transform
 
-import io.arlas.data.model.DataModel
 import io.arlas.data.transform.ArlasTransformerColumns._
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
@@ -29,13 +28,11 @@ import org.apache.spark.sql.{DataFrame, Dataset}
 /**
   * For a ID that is hold by multiple rows, it computes the 'duration of this id'
   * i.a. <oldest row with this id> - <earlier row with this id>
-  * @param dataModel
   * @param idColumn
   * @param durationColumn
   */
-class WithDurationFromId(dataModel: DataModel, idColumn: String, durationColumn: String)
-    extends ArlasTransformer(dataModel,
-                             Vector(idColumn, arlasTrackTimestampStart, arlasTrackTimestampEnd)) {
+class WithDurationFromId(idColumn: String, durationColumn: String)
+    extends ArlasTransformer(Vector(idColumn, arlasTrackTimestampStart, arlasTrackTimestampEnd)) {
 
   override def transform(dataset: Dataset[_]): DataFrame = {
 

--- a/src/main/scala/io/arlas/data/transform/WithFragmentVisibilityFromTempo.scala
+++ b/src/main/scala/io/arlas/data/transform/WithFragmentVisibilityFromTempo.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 class WithFragmentVisibilityFromTempo(dataModel: DataModel,
                                       spark: SparkSession,
                                       irregularTempo: String)
-    extends ArlasTransformer(dataModel, Vector(arlasTimestampColumn, arlasTempoColumn)) {
+    extends ArlasTransformer(Vector(arlasTimestampColumn, arlasTempoColumn, dataModel.idColumn)) {
 
   override def transform(dataset: Dataset[_]): DataFrame = {
 

--- a/src/main/scala/io/arlas/data/transform/WithStateId.scala
+++ b/src/main/scala/io/arlas/data/transform/WithStateId.scala
@@ -40,7 +40,7 @@ class WithStateId(dataModel: DataModel,
                   orderColumn: String,
                   targetIdColumn: String,
                   isNewIdColumn: Column)
-    extends ArlasTransformer(dataModel, Vector(stateColumn, orderColumn)) {
+    extends ArlasTransformer(Vector(stateColumn, orderColumn, dataModel.idColumn)) {
 
   override def transform(dataset: Dataset[_]): DataFrame = {
 

--- a/src/main/scala/io/arlas/data/transform/WithStateIdOnStateChange.scala
+++ b/src/main/scala/io/arlas/data/transform/WithStateIdOnStateChange.scala
@@ -20,7 +20,6 @@
 package io.arlas.data.transform
 
 import io.arlas.data.model.DataModel
-import io.arlas.data.transform.ArlasTransformerColumns.arlasTimestampColumn
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 

--- a/src/main/scala/io/arlas/data/transform/WithSupportValues.scala
+++ b/src/main/scala/io/arlas/data/transform/WithSupportValues.scala
@@ -33,7 +33,6 @@ class WithSupportValues(
     supportValueMaxNumberInGap: Int,
     irregularTempo: String
 ) extends ArlasTransformer(
-      dataModel,
       Vector(arlasTrackDuration, dataModel.distanceColumn, supportColumn, arlasTempoColumn)) {
 
   override def transform(dataset: Dataset[_]): DataFrame = {

--- a/src/test/scala/io/arlas/data/transform/HmmProcessorTest.scala
+++ b/src/test/scala/io/arlas/data/transform/HmmProcessorTest.scala
@@ -134,9 +134,7 @@ class HmmProcessorTest extends ArlasTest {
 
     val transformedDf = visibleSequencesDF
       .enrichWithArlas(
-        new HmmProcessor(dataModel,
-                         spark,
-                         "notExisting",
+        new HmmProcessor("notExisting",
                          MLModelLocal(spark, "src/test/resources/hmm_stillmove_model.json"),
                          arlasVisibleSequenceIdColumn,
                          "result",
@@ -152,9 +150,7 @@ class HmmProcessorTest extends ArlasTest {
 
     val transformedDf = visibleSequencesDF
       .enrichWithArlas(
-        new HmmProcessor(dataModel,
-                         spark,
-                         "speed",
+        new HmmProcessor("speed",
                          MLModelLocal(spark, "src/test/resources/not_existing.json"),
                          arlasVisibleSequenceIdColumn,
                          "result",
@@ -170,9 +166,7 @@ class HmmProcessorTest extends ArlasTest {
 
     val transformedDf = visibleSequencesDF
       .enrichWithArlas(
-        new HmmProcessor(dataModel,
-                         spark,
-                         "speed",
+        new HmmProcessor("speed",
                          MLModelLocal(spark, "src/test/resources/hmm_stillmove_model.json"),
                          arlasVisibleSequenceIdColumn,
                          arlasMovingStateColumn,
@@ -186,9 +180,7 @@ class HmmProcessorTest extends ArlasTest {
     //avoid natural ordering to ensure that hmm doesn't depend on initial order
       .sort(dataModel.latColumn, dataModel.lonColumn)
       .enrichWithArlas(
-        new HmmProcessor(dataModel,
-                         spark,
-                         dataModel.speedColumn,
+        new HmmProcessor(dataModel.speedColumn,
                          motionConfig.movingStateModel,
                          dataModel.idColumn,
                          arlasMovingStateColumn,
@@ -209,9 +201,7 @@ class HmmProcessorTest extends ArlasTest {
 
     val transformedDf = visibleSequencesDF
       .enrichWithArlas(
-        new HmmProcessor(dataModel,
-                         spark,
-                         dataModel.speedColumn,
+        new HmmProcessor(dataModel.speedColumn,
                          motionConfig.movingStateModel,
                          dataModel.idColumn,
                          arlasMovingStateColumn,
@@ -231,9 +221,7 @@ class HmmProcessorTest extends ArlasTest {
     val transformedDf = visibleSequencesDF
       .withColumn("speed", array(col("speed")))
       .enrichWithArlas(
-        new HmmProcessor(dataModel,
-                         spark,
-                         dataModel.speedColumn,
+        new HmmProcessor(dataModel.speedColumn,
                          motionConfig.movingStateModel,
                          dataModel.idColumn,
                          arlasMovingStateColumn,
@@ -283,9 +271,7 @@ class HmmProcessorTest extends ArlasTest {
     //get moving states
     val transformedDf = sourceDF
       .enrichWithArlas(
-        new HmmProcessor(dataModel,
-                         spark,
-                         dataModel.speedColumn,
+        new HmmProcessor(dataModel.speedColumn,
                          motionConfig.movingStateModel,
                          dataModel.idColumn,
                          arlasMovingStateColumn,

--- a/src/test/scala/io/arlas/data/transform/WithDurationFromIdTest.scala
+++ b/src/test/scala/io/arlas/data/transform/WithDurationFromIdTest.scala
@@ -52,7 +52,7 @@ class WithDurationFromIdTest extends ArlasTest {
 
     val transformedDF: DataFrame = baseDF
       .enrichWithArlas(
-        new WithDurationFromId(dataModel, arlasVisibleSequenceIdColumn, "duration")
+        new WithDurationFromId(arlasVisibleSequenceIdColumn, "duration")
       )
 
     assertDataFrameEquality(


### PR DESCRIPTION
Fix #115

Checking of DataModel columns are present & with expected type will be done in a later PR.