### PR TITLE
Remove some useless code

### DIFF
--- a/src/main/scala/io/arlas/data/app/BasicApp.scala
+++ b/src/main/scala/io/arlas/data/app/BasicApp.scala
@@ -74,8 +74,6 @@ trait BasicApp[R <: RunOptions] {
 
   def main(args: Array[String]): Unit = {
 
-    val (sourcePath, targetPath, startStr, stopStr) =
-      (args(0), args(1), args(2), args(3))
     if (args.length == 0) println(usage)
     val arglist = args.toList
     val options = getArgs(Map(), arglist)


### PR DESCRIPTION
Not passing 4 arguments crash the application
whereas at least one is required
    cf if (args.length == 0) println(usage)