### PR TITLE
Crash application if HMM cannnot be applied.

### DIFF
--- a/src/main/scala/io/arlas/data/transform/ml/HmmProcessor.scala
+++ b/src/main/scala/io/arlas/data/transform/ml/HmmProcessor.scala
@@ -59,12 +59,10 @@ class HmmProcessor(sourceColumn: String,
     val hmmModelContent = hmmModel.getModelString()
 
     if (!dataset.columns.contains(sourceColumn)) {
-      logger.error(s"Missing required column ${sourceColumn} to compute HMM")
-      dataset.withColumn(resultColumn, lit(UNKNOWN_RESULT))
+      throw new Exception(s"Missing required column ${sourceColumn} to compute HMM")
 
     } else if (hmmModelContent.isFailure) {
-      logger.error(s"HMM model not found: " + hmmModelContent.failed.get.getMessage)
-      dataset.withColumn(resultColumn, lit(UNKNOWN_RESULT))
+      throw new Exception(s"HMM model not found: " + hmmModelContent.failed.get.getMessage)
 
     } else {
       interpolateRows(dataset, hmmModelContent.get)

--- a/src/test/scala/io/arlas/data/transform/ml/HmmProcessorTest.scala
+++ b/src/test/scala/io/arlas/data/transform/ml/HmmProcessorTest.scala
@@ -56,33 +56,39 @@ class HmmProcessorTest extends ArlasTest {
 
   val baseDF = baseTestDF
 
-  "HmmProcessor " should " have unknown result with not existing source column" in {
+  "HmmProcessor " should " fail with not existing source column" in {
 
-    val expectedDF = baseDF.withColumn(arlasMovingStateColumn, lit("Unknown"))
-    val transformedDF = baseDF
-      .enrichWithArlas(
-        new HmmProcessor("notExisting",
-                         movingStateModel,
-                         partitionColumn,
-                         arlasMovingStateColumn,
-                         5000)
-      )
-    assertDataFrameEquality(transformedDF, expectedDF)
+    val caught =
+      intercept[Exception] {
+        baseDF
+          .enrichWithArlas(
+            new HmmProcessor("notExisting",
+                             movingStateModel,
+                             partitionColumn,
+                             arlasMovingStateColumn,
+                             5000)
+          )
+      }
+
+    assert(caught.getMessage == "Missing required column notExisting to compute HMM")
   }
 
-  "HmmProcessor " should " have unknown result with not existing model" in {
+  "HmmProcessor " should " fail with not existing model" in {
 
-    val expectedDF = baseDF.withColumn(arlasMovingStateColumn, lit("Unknown"))
-    val transformedDF = baseDF
-      .enrichWithArlas(
-        new HmmProcessor(speedColumn,
-                         MLModelLocal(spark, "src/test/resources/not_existing.json"),
-                         partitionColumn,
-                         arlasMovingStateColumn,
-                         5000)
-      )
+    val caught =
+      intercept[Exception] {
+        baseDF
+          .enrichWithArlas(
+            new HmmProcessor(speedColumn,
+                             MLModelLocal(spark, "src/test/resources/not_existing.json"),
+                             partitionColumn,
+                             arlasMovingStateColumn,
+                             5000)
+          )
+      }
 
-    assertDataFrameEquality(transformedDF, expectedDF)
+    assert(caught.getMessage.startsWith("HMM model not found: Input path does not exist:"))
+    assert(caught.getMessage.endsWith("src/test/resources/not_existing.json"))
   }
 
   "HmmProcessor transformation" should " not break using a window shorter than input dataframe" in {


### PR DESCRIPTION
I.a. if input column is missing, or if model is not found.
Previously we used a default value in these cases,
we now prefer to stop the application as we shall
anyway restart the processing after fixing the issue.