### PR TITLE
Speed up test

### DIFF
--- a/src/test/scala/io/arlas/data/TestSparkSession.scala
+++ b/src/test/scala/io/arlas/data/TestSparkSession.scala
@@ -28,6 +28,7 @@ trait TestSparkSession {
       .master("local")
       .appName("Arlas Spark Test")
       .config("spark.driver.memory", "512m")
+      .config("spark.sql.shuffle.partitions", "1")
       .getOrCreate()
   }
 }


### PR DESCRIPTION
According to https://github.com/MrPowers/spark-fast-tests#usage
to can speed up tests (up to 70% faster).
In arlas-proc, a futur PR with course extraction usually needs
7 minutes locally (except sbt & spark session init), and only
5 seconds with this change.