### PR TITLE
Prepare FragmentSummary for CourseExtractor

### DIFF
--- a/src/main/scala/io/arlas/data/transform/features/StopPauseSummaryTransformer.scala
+++ b/src/main/scala/io/arlas/data/transform/features/StopPauseSummaryTransformer.scala
@@ -31,9 +31,10 @@ class StopPauseSummaryTransformer(spark: SparkSession,
   override def getAggregateCondition(): Column =
     col(arlasMovingStateColumn).equalTo(ArlasMovingStates.STILL)
 
-  override def getAggregations(window: WindowSpec): ListMap[String, Column] = ListMap(
-    arlasTrackTrail -> col(arlasTrackLocationPrecisionGeometry)
-  )
+  override def getAggregatedRowsColumns(window: WindowSpec): ListMap[String, Column] =
+    ListMap(
+      arlasTrackTrail -> col(arlasTrackLocationPrecisionGeometry)
+    )
 
   override def getPropagatedColumns(): Seq[String] = {
     Seq(


### PR DESCRIPTION
Update some outdated comments.
Rename getAggregations to getProcessColumnsForResultRows
because there aren't only aggregations.
Manage null values by creating the new result row.
Remove afterAggregations method, finally useless.