### PR TITLE
Fix wiremock not responding during a test

### DIFF
--- a/src/test/scala/io/arlas/data/transform/ArlasMockServer.scala
+++ b/src/test/scala/io/arlas/data/transform/ArlasMockServer.scala
@@ -3,11 +3,14 @@ package io.arlas.data.transform
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import io.arlas.data.app.ArlasProcConfig
-import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatest.{BeforeAndAfterAll, Suite}
+import org.slf4j.LoggerFactory
 
-trait ArlasMockServer extends BeforeAndAfterEach {
+trait ArlasMockServer extends BeforeAndAfterAll {
 
   this: Suite =>
+
+  @transient lazy val logger = LoggerFactory.getLogger(this.getClass)
 
   ArlasProcConfig.GEODATA_BASE_PATH = "http://localhost:8080"
   ArlasProcConfig.REFINE_TRAIL_BASE_PATH = "http://localhost:8080"
@@ -17,12 +20,16 @@ trait ArlasMockServer extends BeforeAndAfterEach {
       .port(8080)
       .usingFilesUnderClasspath("wiremock"))
 
-  override def beforeEach {
+  override protected def beforeAll(): Unit = {
+    logger.info("Starting Wiremock server")
     wireMockServer.start()
+    logger.info("Wiremock server started")
   }
 
-  override def afterEach {
+  override protected def afterAll(): Unit = {
+    logger.info("Stopping Wiremock server")
     wireMockServer.stop()
+    logger.info("Stopping server started")
   }
 
 }


### PR DESCRIPTION
During a travis build, wiremock didn't answer (see
https://api.travis-ci.com/v3/job/258083333/log.txt?log.token=9ejcIaX0MNrYz5y_WXzUxw)
Instead of restarting the server for each test,
we now restart it for each test class.
it should not impact tests results as wiremock has no state.